### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+
+compiler:
+        - clang
+        - gcc
+
+dist: trusty
+
+before_install:
+        - sudo apt-get install libgmp-dev libedit-dev
+        - git submodule init
+        - git submodule update
+env:
+        - INT=gmp
+        - INT=imath
+        - INT=imath-32
+
+script:
+        - ./autogen.sh && ./configure --with-int=$INT --with-clang=system && make && make check


### PR DESCRIPTION
This allows us to run per-commit continious integration on with:

- gcc
- clang

as well as 

--with-int=gmp
--with-int=imath
--with-int=imath-32

In the future we can add more test (e.g., valgrind, other clang versions, ...)
